### PR TITLE
Resolve sendToPlugin Routing to Properly Route to Action Instance

### DIFF
--- a/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
@@ -33,6 +33,9 @@ extension Action {
 	func decodeKeyDown(_ data: Data, using decoder: JSONDecoder) throws {
 		let action = try decoder.decode(ActionEvent<KeyEvent<Settings>>.self, from: data)
 
+        let str = String(decoding: data, as: UTF8.self)
+        NSLog("Redpanda Zero Keydown: \(str)")
+        
 		NSLog("Action \(#function)")
 		keyDown(device: action.device, payload: action.payload)
 	}
@@ -82,7 +85,15 @@ extension Action {
 		NSLog("Action \(#function)")
 		titleParametersDidChange(device: action.device, info: action.payload)
 	}
-
+    
+    /// Decode and deliver a sent to plugin event.
+    /// - Parameters:
+    ///   - data: Event data
+    ///   - decoder: The decoder to use
+    func decodeSentToPlugin(_ data: Data, using decoder: JSONDecoder) throws {
+        let action = try decoder.decode(SendToPluginEvent.self, from: data)
+        sentToPlugin(payload: action.payload)
+    }
 }
 
 

--- a/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
@@ -34,7 +34,6 @@ extension Action {
 		let action = try decoder.decode(ActionEvent<KeyEvent<Settings>>.self, from: data)
 
         let str = String(decoding: data, as: UTF8.self)
-        NSLog("Redpanda Zero Keydown: \(str)")
         
 		NSLog("Action \(#function)")
 		keyDown(device: action.device, payload: action.payload)

--- a/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/Action/Action+Support.swift
@@ -39,7 +39,7 @@ extension Action {
 		keyDown(device: action.device, payload: action.payload)
 	}
 
-	/// Decode and deliver a key down event.
+	/// Decode and deliver a key up event.
 	/// - Parameters:
 	///   - data: Event data
 	///   - decoder: The decoder to use
@@ -50,7 +50,7 @@ extension Action {
 		keyUp(device: action.device, payload: action.payload)
 	}
 
-	/// Decode and deliver a key down event.
+	/// Decode and deliver a will appear event.
 	/// - Parameters:
 	///   - data: Event data
 	///   - decoder: The decoder to use
@@ -63,7 +63,7 @@ extension Action {
 //		return (action: action.action, context: action.context, coordinates: action.payload.coordinates)
 	}
 
-	/// Decode and deliver a key down event.
+	/// Decode and deliver a will dissapear  event.
 	/// - Parameters:
 	///   - data: Event data
 	///   - decoder: The decoder to use
@@ -74,7 +74,7 @@ extension Action {
 		willDisappear(device: action.device, payload: action.payload)
 	}
 
-	/// Decode and deliver a key down event.
+	/// Decode and deliver a title parameters did change event.
 	/// - Parameters:
 	///   - data: Event data
 	///   - decoder: The decoder to use

--- a/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin.swift
@@ -377,10 +377,8 @@ public final class StreamDeckPlugin {
             plugin.propertyInspectorDidDisappear(action: action.action, context: action.context, device: action.device)
         
         case .sendToPlugin:
-            let action = try decoder.decode(SendToPluginEvent.self, from: data)
-
-			NSLog("Forwarding \(event) to PluginDelegate")
-            plugin.sentToPlugin(context: action.context, action: action.action, payload: action.payload)
+            NSLog("Forwarding \(event) to \(context ?? "no context")")
+            try self[context]?.decodeSentToPlugin(data, using: decoder)
         }
     }
 }


### PR DESCRIPTION
While attempting to integrate the `sentToPlugin` on an `Action` instance, I observed that it was not functioning as intended and was instead referring to the `PluginDelegate`.

I took the initiative to rectify the issue by properly routing the function. However, I am unsure of any potential adverse effects and would appreciate your feedback on whether this solution is suitable.
