### PR TITLE
Fixes to let counter example compile

### DIFF
--- a/Examples/counter/Package.resolved
+++ b/Examples/counter/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "StreamDeck",
+        "repositoryURL": "https://github.com/emorydunn/StreamDeckPlugin.git",
+        "state": {
+          "branch": "main",
+          "revision": "90f940adafe6fdc0db09ee8d6836ba8d7342eea8",
+          "version": null
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {

--- a/Examples/counter/Package.swift
+++ b/Examples/counter/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-//        .package(name: "StreamDeck", url: "https://github.com/emorydunn/StreamDeckPlugin.git", .branch("main"))
-		.package(path: "/Users/emorydunn/Repositories/StreamDeck/StreamDeckPlugin"),
+       .package(name: "StreamDeck", url: "https://github.com/emorydunn/StreamDeckPlugin.git", .branch("main")),
+		// .package(path: "path/to/this/repo/StreamDeck/StreamDeckPlugin"), // For local development
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -20,7 +20,7 @@ let package = Package(
         .executableTarget(
             name: "counter",
             dependencies: [
-				.product(name: "StreamDeck", package: "StreamDeckPlugin"),
+				.product(name: "StreamDeck", package: "StreamDeck"),
             ]),
     ]
 )

--- a/Examples/counter/Sources/counter/Actions/DecrementAction.swift
+++ b/Examples/counter/Sources/counter/Actions/DecrementAction.swift
@@ -22,6 +22,10 @@ class DecrementAction: Action {
 		PluginActionState(image: "Icons/actionDefaultImage", titleAlignment: .middle)
 	]
 
+	static var controllers: [ControllerType] = [.encoder]
+
+	static var encoder: RotaryEncoder? = nil;
+
 	var context: String
 
 	var coordinates: StreamDeck.Coordinates?

--- a/Examples/counter/Sources/counter/Actions/DecrementAction.swift
+++ b/Examples/counter/Sources/counter/Actions/DecrementAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 import StreamDeck
 
-class DecrementAction: Action {
+class DecrementAction: KeyAction {
 
 	typealias Settings = NoSettings
 
@@ -21,10 +21,6 @@ class DecrementAction: Action {
 	static var states: [PluginActionState]? = [
 		PluginActionState(image: "Icons/actionDefaultImage", titleAlignment: .middle)
 	]
-
-	static var controllers: [ControllerType] = [.encoder]
-
-	static var encoder: RotaryEncoder? = nil;
 
 	var context: String
 

--- a/Examples/counter/Sources/counter/Actions/IncrementAction.swift
+++ b/Examples/counter/Sources/counter/Actions/IncrementAction.swift
@@ -22,6 +22,10 @@ class IncrementAction: Action {
 		PluginActionState(image: "Icons/actionDefaultImage", titleAlignment: .middle)
 	]
 
+	static var controllers: [ControllerType] = [.encoder]
+
+	static var encoder: RotaryEncoder? = nil;
+
 	var context: String
 	
 	var coordinates: StreamDeck.Coordinates?

--- a/Examples/counter/Sources/counter/Actions/IncrementAction.swift
+++ b/Examples/counter/Sources/counter/Actions/IncrementAction.swift
@@ -8,7 +8,7 @@
 import Foundation
 import StreamDeck
 
-class IncrementAction: Action {
+class IncrementAction: KeyAction {
 
 	typealias Settings = NoSettings
 
@@ -21,10 +21,6 @@ class IncrementAction: Action {
 	static var states: [PluginActionState]? = [
 		PluginActionState(image: "Icons/actionDefaultImage", titleAlignment: .middle)
 	]
-
-	static var controllers: [ControllerType] = [.encoder]
-
-	static var encoder: RotaryEncoder? = nil;
 
 	var context: String
 	


### PR DESCRIPTION
On the main branch, if I cd into `Example/counter` and run `swift build` I am unable to compile the plugin due to some errors. These changes fix those errors.