### PR TITLE
Update SDK documentation link for Manifest in PluginManifest.swift

### DIFF
--- a/Sources/StreamDeck/Support Models/PluginManifest/PluginManifest.swift
+++ b/Sources/StreamDeck/Support Models/PluginManifest/PluginManifest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// The manifest file providing plugin details.
 ///
-/// See the [SDK documentation](https://developer.elgato.com/documentation/stream-deck/sdk/manifest/) for more information.
+/// See the [SDK documentation](https://docs.elgato.com/streamdeck/sdk/references/manifest) for more information.
 struct PluginManifest: Codable {
 
 	/// The name of the plugin.


### PR DESCRIPTION
URL in code was 404 replace with new url: https://docs.elgato.com/streamdeck/sdk/references/manifest