### PR TITLE
Update to indicate manifest v3

### DIFF
--- a/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin/SDPlugin+Support.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin/SDPlugin+Support.swift
@@ -43,7 +43,7 @@ public extension Plugin {
 
 	static var url: URL? { nil }
 
-	static var sdkVersion: Int { 2 }
+	static var sdkVersion: Int { 3 }
 	
 	static var software: StreamDeck.PluginSoftware { .minimumVersion("5.0") }
 

--- a/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin/StreamDeckPlugin.swift
+++ b/Sources/StreamDeck/StreamDeck Plugin/StreamDeckPlugin/StreamDeckPlugin.swift
@@ -75,7 +75,7 @@ public protocol Plugin {
 	/// Indicates which version of the Stream Deck application is required to install the plugin.
 	static var software: PluginSoftware { get }
 	
-	/// This value should be set to 2.
+	/// This value should be set to 3.
 	static var sdkVersion: Int { get }
 	
 	/// The relative path to the HTML/binary file containing the code of the plugin.

--- a/Sources/StreamDeck/Support Models/PluginManifest/PluginManifest.swift
+++ b/Sources/StreamDeck/Support Models/PluginManifest/PluginManifest.swift
@@ -68,7 +68,7 @@ struct PluginManifest: Codable {
 	/// Indicates which version of the Stream Deck application is required to install the plugin.
 	var software: PluginSoftware
 
-	/// This value should be set to 2.
+	/// This value should be set to 3.
 	var sdkVersion: Int
 
 	/// The relative path to the HTML/binary file containing the code of the plugin.
@@ -102,7 +102,7 @@ struct PluginManifest: Codable {
 	///   - os: The list of operating systems supported by the plugin as well as the minimum supported version of the operating system.
 	///   - applicationsToMonitor: List of application identifiers to monitor (applications launched or terminated).
 	///   - software: Indicates which version of the Stream Deck application is required to install the plugin.
-	///   - sdkVersion: This value should be set to 2.
+	///   - sdkVersion: This value should be set to 3.
 	///   - codePath: The relative path to the HTML/binary file containing the code of the plugin. Defaults to the executable name.
 	///   - codePathMac: Override CodePath for macOS.
 	///   - codePathWin: Override CodePath for Windows.
@@ -118,7 +118,7 @@ struct PluginManifest: Codable {
 		 os: [PluginOS],
 		 applicationsToMonitor: ApplicationsToMonitor? = nil,
 		 software: PluginSoftware,
-		 sdkVersion: Int = 2,
+		 sdkVersion: Int = 3,
 		 codePath: String = PluginManifest.executableName,
 		 codePathMac: String? = nil,
 		 codePathWin: String? = nil,
@@ -156,7 +156,7 @@ struct PluginManifest: Codable {
 	///   - os: The list of operating systems supported by the plugin as well as the minimum supported version of the operating system.
 	///   - applicationsToMonitor: List of application identifiers to monitor (applications launched or terminated).
 	///   - software: Indicates which version of the Stream Deck application is required to install the plugin.
-	///   - sdkVersion: This value should be set to 2.
+	///   - sdkVersion: This value should be set to 3.
 	///   - codePath: The relative path to the HTML/binary file containing the code of the plugin. Defaults to the executable name.
 	///   - codePathMac: Override CodePath for macOS.
 	///   - codePathWin: Override CodePath for Windows.
@@ -172,7 +172,7 @@ struct PluginManifest: Codable {
 		 os: [PluginOS],
 		 applicationsToMonitor: ApplicationsToMonitor? = nil,
 		 software: PluginSoftware,
-		 sdkVersion: Int = 2,
+		 sdkVersion: Int = 3,
 		 codePath: String = PluginManifest.executableName,
 		 codePathMac: String? = nil,
 		 codePathWin: String? = nil,

--- a/Tests/StreamDeckPluginTests/PluginManifestTests.swift
+++ b/Tests/StreamDeckPluginTests/PluginManifestTests.swift
@@ -24,7 +24,7 @@ final class PluginManifestTests: XCTestCase {
 			],
 			applicationsToMonitor: ApplicationsToMonitor(mac: ["com.test.app"]),
 			software: .minimumVersion("4.1"),
-			sdkVersion: 2,
+			sdkVersion: 3,
 			codePath: "counter-plugin",
 			actions: [
 				PluginAction(

--- a/Tests/StreamDeckPluginTests/Support/TestPlugin.swift
+++ b/Tests/StreamDeckPluginTests/Support/TestPlugin.swift
@@ -103,7 +103,7 @@ class TestPlugin: Plugin {
 	
 	static var software: PluginSoftware = .minimumVersion("4.1")
 	
-	static var sdkVersion: Int = 2
+	static var sdkVersion: Int = 3
 	
 	static var codePath: String = TestPlugin.executableName
 	


### PR DESCRIPTION
When submitting my plugin to the marketplace this banner was there:

> Stream Deck plugin changes
> From January 19, 2026, new plugins will be required to be DRM compatible, and have a minimum Stream Deck version of 6.9 or higher, and manifest SDK version of 3 or higher. From February 19, 2026, this will also apply to new plugin version updates.[Learn more](https://docs.elgato.com/streamdeck/sdk/introduction/distribution/#drm-protection)

I have updated the code to indicate manifest SDK version 3 or higher and I have **successfully** submitted a plugin and published it to the market place with this code.